### PR TITLE
Make db_nmap Work With Remote Data Service

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/data_proxy_auto_loader.rb
+++ b/lib/metasploit/framework/data_service/proxy/data_proxy_auto_loader.rb
@@ -28,4 +28,5 @@ module DataProxyAutoLoader
   include LootDataProxy
   include SessionEventDataProxy
   include CredentialDataProxy
+  include NmapDataProxy
 end

--- a/lib/metasploit/framework/data_service/proxy/data_proxy_auto_loader.rb
+++ b/lib/metasploit/framework/data_service/proxy/data_proxy_auto_loader.rb
@@ -15,6 +15,7 @@ module DataProxyAutoLoader
   autoload :LootDataProxy, 'metasploit/framework/data_service/proxy/loot_data_proxy'
   autoload :SessionEventDataProxy, 'metasploit/framework/data_service/proxy/session_event_data_proxy'
   autoload :CredentialDataProxy, 'metasploit/framework/data_service/proxy/credential_data_proxy'
+  autoload :NmapDataProxy, 'metasploit/framework/data_service/proxy/nmap_data_proxy'
   include ServiceDataProxy
   include HostDataProxy
   include VulnDataProxy

--- a/lib/metasploit/framework/data_service/proxy/nmap_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/nmap_data_proxy.rb
@@ -1,0 +1,12 @@
+module NmapDataProxy
+
+  def import_nmap_xml_file(args = {})
+    begin
+      data_service = self.get_data_service()
+      data_service.import_nmap_xml_file(args)
+    rescue Exception => e
+      puts "Call to #{data_service.class}#import_nmap_xml_file threw exception: #{e.message}"
+      e.backtrace { |line| puts "#{line}\n"}
+    end
+  end
+end

--- a/lib/metasploit/framework/data_service/remote/http/data_service_auto_loader.rb
+++ b/lib/metasploit/framework/data_service/remote/http/data_service_auto_loader.rb
@@ -14,6 +14,7 @@ module DataServiceAutoLoader
   autoload :RemoteLootDataService, 'metasploit/framework/data_service/remote/http/remote_loot_data_service'
   autoload :RemoteSessionEventDataService, 'metasploit/framework/data_service/remote/http/remote_session_event_data_service'
   autoload :RemoteCredentialDataService, 'metasploit/framework/data_service/remote/http/remote_credential_data_service'
+  autoload :RemoteNmapDataService, 'metasploit/framework/data_service/remote/http/remote_nmap_data_service'
   include RemoteHostDataService
   include RemoteEventDataService
   include RemoteNoteDataService
@@ -26,4 +27,5 @@ module DataServiceAutoLoader
   include RemoteLootDataService
   include RemoteSessionEventDataService
   include RemoteCredentialDataService
+  include RemoteNmapDataService
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
@@ -6,7 +6,16 @@ module RemoteLootDataService
   LOOT_PATH = '/api/1/msf/loot'
 
   def loot(opts = {})
-    json_to_open_struct_object(self.get_data(LOOT_PATH, opts), [])
+    # TODO: Add an option to toggle whether the file data is returned or not
+    loots = json_to_open_struct_object(self.get_data(LOOT_PATH, opts), [])
+    # Save a local copy of the file
+    loots.each do |loot|
+      if loot.data
+        local_path = File.join(Msf::Config.loot_directory, File.basename(loot.path))
+        loot.path = process_file(loot.data, local_path)
+      end
+    end
+    loots
   end
 
   def report_loot(opts)

--- a/lib/metasploit/framework/data_service/remote/http/remote_nmap_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_nmap_data_service.rb
@@ -1,0 +1,11 @@
+require 'metasploit/framework/data_service/remote/http/response_data_helper'
+
+module RemoteLootDataService
+  include ResponseDataHelper
+
+  NMAP_PATH = '/api/1/msf/nmap'
+
+  def import_nmap_xml_file(args)
+    self.post_data_async(NMAP_PATH, args)
+  end
+end

--- a/lib/metasploit/framework/data_service/remote/http/remote_nmap_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_nmap_data_service.rb
@@ -14,6 +14,6 @@ module RemoteNmapDataService
 
     opts[:data] = Base64.urlsafe_encode64(data)
 
-    self.post_data_async(NMAP_PATH, opts)
+    self.post_data(NMAP_PATH, opts)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_nmap_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_nmap_data_service.rb
@@ -1,11 +1,19 @@
 require 'metasploit/framework/data_service/remote/http/response_data_helper'
 
-module RemoteLootDataService
+module RemoteNmapDataService
   include ResponseDataHelper
 
   NMAP_PATH = '/api/1/msf/nmap'
 
-  def import_nmap_xml_file(args)
-    self.post_data_async(NMAP_PATH, args)
+  def import_nmap_xml_file(opts)
+    filename = opts[:filename]
+    data = ""
+    File.open(filename, 'rb') do |f|
+      data = f.read(f.stat.size)
+    end
+
+    opts[:data] = Base64.urlsafe_encode64(data)
+
+    self.post_data_async(NMAP_PATH, opts)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
+++ b/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require 'digest'
 
 #
 # HTTP response helper class
@@ -27,21 +28,21 @@ module ResponseDataHelper
   # Saves the file in the location specified in the parameter.
   #
   # @param base64_file [String] The Base64 encoded file.
-  # @param save_dir [String] The location to store the file. This should include the file's name.
+  # @param save_path [String] The location to store the file. This should include the file's name.
   # @return [String] The location where the file was successfully stored.
-  def process_file(base64_file, save_dir)
+  def process_file(base64_file, save_path)
     decoded_file = Base64.urlsafe_decode64(base64_file)
     begin
       # If we are running the data service on the same box this will ensure we only write
       # the file if it is somehow not there already.
-      unless File.exists?(save_dir) && File.read(save_dir) == decoded_file
-        File.open(save_dir, 'w+') { |file| file.write(decoded_file) }
+      unless File.exists?(save_path) && File.read(save_path) == decoded_file
+        File.open(save_path, 'w+') { |file| file.write(decoded_file) }
       end
     rescue Exception => e
       puts "There was an error writing the file: #{e}"
       e.backtrace.each { |line| puts "#{line}\n"}
     end
-    save_dir
+    save_path
   end
 
   #

--- a/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
+++ b/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb
@@ -23,6 +23,27 @@ module ResponseDataHelper
     return returns_on_error
   end
 
+  # Processes a Base64 encoded file included in a JSON request.
+  # Saves the file in the location specified in the parameter.
+  #
+  # @param base64_file [String] The Base64 encoded file.
+  # @param save_dir [String] The location to store the file. This should include the file's name.
+  # @return [String] The location where the file was successfully stored.
+  def process_file(base64_file, save_dir)
+    decoded_file = Base64.urlsafe_decode64(base64_file)
+    begin
+      # If we are running the data service on the same box this will ensure we only write
+      # the file if it is somehow not there already.
+      unless File.exists?(save_dir) && File.read(save_dir) == decoded_file
+        File.open(save_dir, 'w+') { |file| file.write(decoded_file) }
+      end
+    rescue Exception => e
+      puts "There was an error writing the file: #{e}"
+      e.backtrace.each { |line| puts "#{line}\n"}
+    end
+    save_dir
+  end
+
   #
   # Converts a hash to an open struct
   #

--- a/lib/msf/core/db_manager/http/servlet/loot_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/loot_servlet.rb
@@ -27,12 +27,11 @@ module LootServlet
 
   def self.report_loot
     lambda {
-
       job = lambda { |opts|
         if opts[:data]
           filename = File.basename(opts[:path])
           local_path = File.join(Msf::Config.loot_directory, filename)
-          process_file(opts[:data], local_path)
+          opts[:path] = process_file(opts[:data], local_path)
         end
 
         get_db().report_loot(opts)

--- a/lib/msf/core/db_manager/http/servlet/loot_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/loot_servlet.rb
@@ -29,46 +29,10 @@ module LootServlet
     lambda {
 
       job = lambda { |opts|
-        # This regex does a best attempt to determine if opts[:data] is valid Base64
-        # See https://stackoverflow.com/questions/8571501/how-to-check-whether-the-string-is-base64-encoded-or-not
-        if opts[:data] =~ /^([A-Za-z0-9+\/]{4})*([A-Za-z0-9+\/]{4}|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{2}==)$/
-          opts[:data] = Base64.urlsafe_decode64(opts[:data]) if opts[:data]
-        end
-
-        # This code is all for writing out the file locally.
-        # It is copied from lib/msf/core/auxiliary/report.rb
-        # We shouldn't duplicate it so a better method should be used
-        if ! ::File.directory?(Msf::Config.loot_directory)
-          FileUtils.mkdir_p(Msf::Config.loot_directory)
-        end
-
-        ext = 'bin'
-        if opts[:name]
-          parts = opts[:name].to_s.split('.')
-          if parts.length > 1 and parts[-1].length < 4
-            ext = parts[-1]
-          end
-        end
-
-        case opts[:content_type]
-          when /^text\/[\w\.]+$/
-            ext = "txt"
-        end
-        # This method is available even if there is no database, don't bother checking
-        host = Msf::Util::Host.normalize_host(opts[:host])
-
-        ws = (opts[:workspace] ? opts[:workspace] : 'default')
-        name =
-            Time.now.strftime("%Y%m%d%H%M%S") + "_" + ws + "_" +
-                (host || 'unknown') + '_' + opts[:type][0,16] + '_' +
-                Rex::Text.rand_text_numeric(6) + '.' + ext
-
-        name.gsub!(/[^a-z0-9\.\_]+/i, '')
-
-        path = File.join(Msf::Config.loot_directory, name)
-        full_path = ::File.expand_path(path)
-        File.open(full_path, "wb") do |fd|
-          fd.write(opts[:data])
+        if opts[:data]
+          filename = File.basename(opts[:path])
+          local_path = File.join(Msf::Config.loot_directory, filename)
+          process_file(opts[:data], local_path)
         end
 
         get_db().report_loot(opts)

--- a/lib/msf/core/db_manager/http/servlet/nmap_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/nmap_servlet.rb
@@ -1,11 +1,11 @@
-module nmapServlet
+module NmapServlet
 
   def self.api_path
     '/api/1/msf/nmap'
   end
 
   def self.registered(app)
-    app.post nmapServlet.api_path, &import_nmap_xml_file
+    app.post NmapServlet.api_path, &import_nmap_xml_file
   end
 
   #######
@@ -16,6 +16,12 @@ module nmapServlet
     lambda {
 
       job = lambda { |opts|
+
+        nmap_file = opts[:filename].split('/').last
+        local_file = File.open(File.join(Msf::Config.local_directory, nmap_file), 'w')
+        local_file.write(Base64.urlsafe_decode64(opts[:data]))
+        local_file.close
+        opts[:filename] = File.expand_path(local_file)
         get_db().import_nmap_xml_file(opts)
       }
       exec_report_job(request, &job)

--- a/lib/msf/core/db_manager/http/servlet/nmap_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/nmap_servlet.rb
@@ -1,0 +1,24 @@
+module nmapServlet
+
+  def self.api_path
+    '/api/1/msf/nmap'
+  end
+
+  def self.registered(app)
+    app.post nmapServlet.api_path, &import_nmap_xml_file
+  end
+
+  #######
+  private
+  #######
+
+  def self.import_nmap_xml_file
+    lambda {
+
+      job = lambda { |opts|
+        get_db().import_nmap_xml_file(opts)
+      }
+      exec_report_job(request, &job)
+    }
+  end
+end

--- a/lib/msf/core/db_manager/http/servlet/nmap_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/nmap_servlet.rb
@@ -16,7 +16,7 @@ module NmapServlet
     lambda {
 
       job = lambda { |opts|
-        nmap_file = opts[:filename].split('/').last
+        nmap_file = File.basename(opts[:filename])
         nmap_file_path = File.join(Msf::Config.local_directory, nmap_file)
         opts[:filename] = process_file(opts[:data], nmap_file_path)
         get_db().import_nmap_xml_file(opts)

--- a/lib/msf/core/db_manager/http/servlet/nmap_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/nmap_servlet.rb
@@ -16,12 +16,9 @@ module NmapServlet
     lambda {
 
       job = lambda { |opts|
-
         nmap_file = opts[:filename].split('/').last
-        local_file = File.open(File.join(Msf::Config.local_directory, nmap_file), 'w')
-        local_file.write(Base64.urlsafe_decode64(opts[:data]))
-        local_file.close
-        opts[:filename] = File.expand_path(local_file)
+        nmap_file_path = File.join(Msf::Config.local_directory, nmap_file)
+        opts[:filename] = process_file(opts[:data], nmap_file_path)
         get_db().import_nmap_xml_file(opts)
       }
       exec_report_job(request, &job)

--- a/lib/msf/core/db_manager/http/servlet_helper.rb
+++ b/lib/msf/core/db_manager/http/servlet_helper.rb
@@ -57,27 +57,6 @@ module ServletHelper
     DBManagerProxy.instance.db
   end
 
-  # Processes a Base64 encoded file included in a JSON request.
-  # Saves the file in the location specified in the parameter.
-  #
-  # @param base64_file [String] The Base64 encoded file.
-  # @param save_dir [String] The location to store the file. This should include the file's name.
-  # @return [String] The location where the file was successfully stored.
-  def process_file(base64_file, save_dir)
-    decoded_file = Base64.urlsafe_decode64(base64_file)
-    begin
-      # If we are running the data service on the same box this will ensure we only write
-      # the file if it is somehow not there already.
-      unless File.exists?(save_dir) && File.read(save_dir) == decoded_file
-        File.open(save_dir, 'r+') { |file| file.write(decoded_file) }
-      end
-    rescue Exception => e
-      puts "There was an error writing the file: #{e}"
-      e.backtrace.each { |line| puts "#{line}\n"}
-    end
-    save_dir
-  end
-
   #######
   private
   #######

--- a/lib/msf/core/db_manager/http/servlet_helper.rb
+++ b/lib/msf/core/db_manager/http/servlet_helper.rb
@@ -57,6 +57,27 @@ module ServletHelper
     DBManagerProxy.instance.db
   end
 
+  # Processes a Base64 encoded file included in a JSON request.
+  # Saves the file in the location specified in the parameter.
+  #
+  # @param base64_file [String] The Base64 encoded file.
+  # @param save_dir [String] The location to store the file. This should include the file's name.
+  # @return [String] The location where the file was successfully stored.
+  def process_file(base64_file, save_dir)
+    decoded_file = Base64.urlsafe_decode64(base64_file)
+    begin
+      # If we are running the data service on the same box this will ensure we only write
+      # the file if it is somehow not there already.
+      unless File.exists?(save_dir) && File.read(save_dir) == decoded_file
+        File.open(save_dir, 'r+') { |file| file.write(decoded_file) }
+      end
+    rescue Exception => e
+      puts "There was an error writing the file: #{e}"
+      e.backtrace.each { |line| puts "#{line}\n"}
+    end
+    save_dir
+  end
+
   #######
   private
   #######

--- a/lib/msf/core/db_manager/http/sinatra_app.rb
+++ b/lib/msf/core/db_manager/http/sinatra_app.rb
@@ -14,6 +14,7 @@ require 'msf/core/db_manager/http/servlet/exploit_servlet'
 require 'msf/core/db_manager/http/servlet/loot_servlet'
 require 'msf/core/db_manager/http/servlet/session_event_servlet'
 require 'msf/core/db_manager/http/servlet/credential_servlet'
+require 'msf/core/db_manager/http/servlet/nmap_servlet'
 
 class SinatraApp < Sinatra::Base
 
@@ -35,4 +36,5 @@ class SinatraApp < Sinatra::Base
   register LootServlet
   register SessionEventServlet
   register CredentialServlet
+  register NmapServlet
 end


### PR DESCRIPTION
This PR enables db_nmap functionality with a remote data service. It performs the scan on the client, then sends the resulting XML file to the RDS encoded as Base64 in the JSON request. It is then processed on the server and the data is added to the DB there.

I also did some refactoring and bug fixing related to the loot data store. There was some code duplication that wasn't necessary in remote_loot_data_service.rb. I also made it so the client stores a local copy of the loot file when it is requested from the server, since feedback I have heard says people just go look at the files directly in their Msf::Config.loot_directory instead of using the command line.

Verification:
- [ ] Start up `msfconsole` with a clean DB and `~/.msf4/loot/` and `~/.msf4/local` directories
- [ ] Start up `msfdb`, preferably on a true remote host such as a VM. Ensure this DB and directories are empty as well.
- [ ] Add the data service on msfconsole: `add_data_service -h <host> -p <port>`
- [ ] Run `db_nmap` against a scanable host from msfconsole. Verify the `hosts` data displays correctly. Verify the xml file is stored in `~/.msf4/loot/` on the server.
- [ ] Get a session on remote machine and run a post module to gather loot. I tested with `post/linux/gather/hashdump`.
- [ ] Run the `loot` command and verify the loot displays properly. Verify the `path` output on the client displays the local directory. Check the `~/.msf4/loot` directory on the client has copies of the loot files. 
