### PR TITLE
Move session mdm use

### DIFF
--- a/lib/metasploit/framework/data_service/stubs/session_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/session_data_service.rb
@@ -1,5 +1,5 @@
 module SessionDataService
   def report_session(opts)
-    raise 'SessionDataService#report_vuln is not implemented'
+    raise 'SessionDataService#report_session is not implemented'
   end
 end


### PR DESCRIPTION
Move the last Mdm::Session use under db_manager session.

## Verification
- [x] Start `msfconsole`
- [x] Create one or more sessions
- [x] Exit msfconsole with `exit -y`
- [x] Start `msfconsole`
- [x] Start IRB shell `irb`
- [x] Run `::Mdm::Session.where(closed_at: nil)` and you should note entries for the sessions created above
- [x] **Verify** Mdm::Session records have been marked closed by running the `::Mdm::Session.where(closed_at: nil)` command again in the IRB shell and noting the previous records are no longer returned. Note, you should not have to wait much more than 5 minutes until the `SessionManager` monitor thread calls the `framework.db.remove_stale_sessions` method and successfully cleans up these session DB entries.