### PR TITLE
Externalize hosts delete

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
@@ -26,7 +26,7 @@ module HostDataProxy
       data_service.report_host(opts)
     rescue Exception => e
       puts "Call to #{data_service.class}#report_host threw exception: #{e.message}"
-      opts.each do |key, value| puts "#{key} : #{value}" end
+      opts.each { |k, v| puts "#{k} : #{v}" }
     end
   end
 

--- a/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
@@ -1,6 +1,6 @@
 module HostDataProxy
 
-  def hosts(wspace, non_dead = false, addresses = nil)
+  def hosts(wspace = workspace, non_dead = false, addresses = nil)
     begin
       data_service = self.get_data_service()
       opts = {}
@@ -8,8 +8,8 @@ module HostDataProxy
       opts[:non_dead] = non_dead
       opts[:addresses] = addresses
       data_service.hosts(opts)
-    rescue  Exception => e
-      puts"Call to  #{data_service.class}#hosts threw exception: #{e.message}"
+    rescue Exception => e
+      puts "Call to #{data_service.class}#hosts threw exception: #{e.message}"
     end
   end
 
@@ -24,9 +24,9 @@ module HostDataProxy
     begin
       data_service = self.get_data_service()
       data_service.report_host(opts)
-    rescue  Exception => e
-        puts"Call to  #{data_service.class}#report_host threw exception: #{e.message}"
-        opts.each do |key, value| puts "#{key} : #{value}" end
+    rescue Exception => e
+      puts "Call to #{data_service.class}#report_host threw exception: #{e.message}"
+      opts.each do |key, value| puts "#{key} : #{value}" end
     end
   end
 
@@ -34,8 +34,17 @@ module HostDataProxy
     begin
       data_service = self.get_data_service()
       data_service.report_hosts(hosts)
-    rescue  Exception => e
-      puts "Call to  #{data_service.class}#report_hosts threw exception: #{e.message}"
+    rescue Exception => e
+      puts "Call to #{data_service.class}#report_hosts threw exception: #{e.message}"
+    end
+  end
+
+  def delete_host(opts)
+    begin
+      data_service = self.get_data_service()
+      data_service.delete_host(opts)
+    rescue Exception => e
+      puts "Call to #{data_service.class}#delete_host threw exception: #{e.message}"
     end
   end
 

--- a/lib/metasploit/framework/data_service/remote/http/core.rb
+++ b/lib/metasploit/framework/data_service/remote/http/core.rb
@@ -18,6 +18,7 @@ class RemoteHTTPDataService
   EXEC_ASYNC = { :exec_async => true }
   GET_REQUEST = 'GET'
   POST_REQUEST = 'POST'
+  DELETE_REQUEST = 'DELETE'
 
   #
   # @param endpoint - A RemoteServiceEndpoint. Cannot be nil
@@ -59,15 +60,29 @@ class RemoteHTTPDataService
     make_request(GET_REQUEST, path, data_hash)
   end
 
+  #
+  # Send DELETE request to delete the specified resource from the HTTP endpoint
+  #
+  # @param path - The URI path to send the delete
+  # @param data_hash - A hash representation of the object to be deleted. Cannot be nil or empty.
+  #
+  # @return A wrapped response (ResponseWrapper), see below.
+  #
+  def delete_data(path, data_hash)
+    make_request(DELETE_REQUEST, path, data_hash)
+  end
+
   def make_request(request_type, path, data_hash = nil)
     begin
       puts "#{Time.now} - HTTP #{request_type} request to #{path} with #{data_hash ? data_hash : "nil"}"
-      client =  @client_pool.pop()
+      client = @client_pool.pop()
       case request_type
         when GET_REQUEST
           request = Net::HTTP::Get.new(path)
         when POST_REQUEST
           request = Net::HTTP::Post.new(path)
+        when DELETE_REQUEST
+          request = Net::HTTP::Delete.new(path)
         else
           raise Exception, 'A request_type must be specified'
       end

--- a/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
@@ -11,17 +11,22 @@ module RemoteHostDataService
   end
 
   def report_host(opts)
-    self.post_data_async(HOST_PATH, opts)
+    json_to_open_struct_object(self.post_data(HOST_PATH, opts))
   end
 
   def find_or_create_host(opts)
-    json_to_open_struct_object(self.post_data(HOST_PATH, host))
+    json_to_open_struct_object(self.post_data(HOST_PATH, opts))
   end
 
   def report_hosts(hosts)
     self.post_data(HOST_PATH, hosts)
   end
 
+  def delete_host(opts)
+    json_to_open_struct_object(self.delete_data(HOST_PATH, opts))
+  end
+
+  # TODO: Remove? What is the purpose of this method?
   def do_host_search(search)
     response = self.post_data(HOST_SEARCH_PATH, search)
     return response.body

--- a/lib/metasploit/framework/data_service/stubs/host_data_service.rb
+++ b/lib/metasploit/framework/data_service/stubs/host_data_service.rb
@@ -15,4 +15,8 @@ module HostDataService
   def find_or_create_host(opts)
     raise 'HostDataService#find_or_create_host is not implemented'
   end
+
+  def delete_host(opts)
+    raise 'HostDataService#delete_host is not implemented'
+  end
 end

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -15,20 +15,16 @@ module Msf::DBManager::Host
       wspace = find_workspace(wspace)
     end
 
-    dlog("delete_host(): wspace=#{wspace}, opts=#{opts}")
-    puts("delete_host(): wspace=#{wspace}, opts=#{opts}")
-
     ::ActiveRecord::Base.connection_pool.with_connection {
       hosts = []
-      if opts[:host] || opts[:address]
-        opts_host = opts[:host] || opts[:address]
-        host = wspace.hosts.find_by_address(opts_host)
+      if opts[:address] || opts[:host]
+        opt_addr = opts[:address] || opts[:host]
+        host = wspace.hosts.find_by_address(opt_addr)
         return { error: { message: "Unable to find host by specified address" } } if host.nil? || host.class != ::Mdm::Host
         hosts << host
       elsif opts[:addresses]
         return { error: { message: "Unable to find host by specified addresses" } } if opts[:addresses].class != Array
-        conditions = { address: opts[:addresses] }
-        hosts = wspace.hosts.where(conditions)
+        hosts = wspace.hosts.where(address: opts[:addresses])
         return { error: { message: "Unable to find hosts for specified addresses" } } if hosts.nil?
       end
 
@@ -38,8 +34,7 @@ module Msf::DBManager::Host
           host.destroy
           deleted << host.address.to_s
         rescue # refs suck
-          dlog("Forcibly deleting #{host.address}")
-          puts("delete_host(): Forcibly deleting #{host.address}...")
+          elog("Forcibly deleting #{host.address}")
           host.delete
           deleted << host.address.to_s
         end

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -22,8 +22,9 @@ module Msf::DBManager::Host
       hosts = []
       if opts[:host] || opts[:address]
         opts_host = opts[:host] || opts[:address]
-        hosts = wspace.hosts.find_by_address(opts_host)
-        return { error: { message: "Unable to find host by specified address" } } if hosts.nil? || hosts.class != ::Mdm::Host
+        host = wspace.hosts.find_by_address(opts_host)
+        return { error: { message: "Unable to find host by specified address" } } if host.nil? || host.class != ::Mdm::Host
+        hosts << host
       elsif opts[:addresses]
         return { error: { message: "Unable to find host by specified addresses" } } if opts[:addresses].class != Array
         conditions = { address: opts[:addresses] }

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -1,4 +1,5 @@
 module Msf::DBManager::Host
+  # TODO: doesn't appear to have any callers. How is this used?
   # Deletes a host and associated data matching this address/comm
   def del_host(wspace, address, comm='')
   ::ActiveRecord::Base.connection_pool.with_connection {
@@ -6,6 +7,45 @@ module Msf::DBManager::Host
     host = wspace.hosts.find_by_address_and_comm(address, comm)
     host.destroy if host
   }
+  end
+
+  def delete_host(opts)
+    wspace = opts[:workspace] || opts[:wspace] || workspace
+    if wspace.is_a? String
+      wspace = find_workspace(wspace)
+    end
+
+    dlog("delete_host(): wspace=#{wspace}, opts=#{opts}")
+    puts("delete_host(): wspace=#{wspace}, opts=#{opts}")
+
+    ::ActiveRecord::Base.connection_pool.with_connection {
+      hosts = []
+      if opts[:host] || opts[:address]
+        opts_host = opts[:host] || opts[:address]
+        hosts = wspace.hosts.find_by_address(opts_host)
+        return { error: { message: "Unable to find host by specified address" } } if hosts.nil? || hosts.class != ::Mdm::Host
+      elsif opts[:addresses]
+        return { error: { message: "Unable to find host by specified addresses" } } if opts[:addresses].class != Array
+        conditions = { address: opts[:addresses] }
+        hosts = wspace.hosts.where(conditions)
+        return { error: { message: "Unable to find hosts for specified addresses" } } if hosts.nil?
+      end
+
+      deleted = []
+      hosts.each do |host|
+        begin
+          host.destroy
+          deleted << host.address.to_s
+        rescue # refs suck
+          dlog("Forcibly deleting #{host.address}")
+          puts("delete_host(): Forcibly deleting #{host.address}...")
+          host.delete
+          deleted << host.address.to_s
+        end
+      end
+
+      return { deleted: deleted }
+    }
   end
 
   #

--- a/lib/msf/core/db_manager/http/servlet/host_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/host_servlet.rb
@@ -7,6 +7,7 @@ module HostServlet
   def self.registered(app)
     app.get HostServlet.api_path, &get_host
     app.post HostServlet.api_path, &report_host
+    app.delete HostServlet.api_path, &delete_host
   end
 
   #######
@@ -28,8 +29,27 @@ module HostServlet
 
   def self.report_host
     lambda {
-        job = lambda { |opts| get_db().report_host(opts) }
+      begin
+        job = lambda { |opts|
+          data = get_db().report_host(opts)
+        }
         exec_report_job(request, &job)
+      rescue Exception => e
+        set_error_on_response(e)
+      end
     }
   end
+
+  def self.delete_host
+    lambda {
+      begin
+        opts = parse_json_request(request, false)
+        data = get_db().delete_host(opts)
+        set_json_response(data)
+      rescue Exception => e
+        set_error_on_response(e)
+      end
+    }
+  end
+
 end


### PR DESCRIPTION
Implements hosts remote data store delete functionality. In addition, resolves an issue when adding a host to a remote data store where the client-side currently raises an exception.

## Verification

- [x] Start `msfconsole`
- [x] Start `msfdb` on remote server
- [x] Connect to the remote data service `add_data_service -h <address> -p 8080`
- [x] Check existing hosts on the remote data store by listing the hosts `hosts`
- [x] Add a new host `hosts --add <address>`
- [x] **Verify** host was added to the remote data store by listing the hosts and confirming its presence in the list `hosts`
- [x] Delete the host added above `hosts --delete <address>`
- [x] **Verify** host was deleted from the remote data store by listing the hosts and confirming it no longer exists in the list `hosts`