### PR TITLE
Json to mdm

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
@@ -13,6 +13,8 @@ module HostDataProxy
     end
   end
 
+  # TODO: Shouldn't this proxy to RemoteHostDataService#find_or_create_host ?
+  # It's currently skipping the "find" part
   def find_or_create_host(opts)
     puts 'Calling find host'
     report_host(opts)

--- a/lib/metasploit/framework/data_service/remote/http/remote_credential_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_credential_data_service.rb
@@ -3,13 +3,15 @@ require 'metasploit/framework/data_service/remote/http/response_data_helper'
 module RemoteCredentialDataService
   include ResponseDataHelper
 
-  CREDENTIAL_PATH = '/api/1/msf/credential'
+  CREDENTIAL_API_PATH = '/api/1/msf/credential'
+  # "MDM_CLASS" is a little misleading since it is not in that repo but trying to keep naming consistent across DataServices
+  CREDENTIAL_MDM_CLASS = 'Metasploit::Credential::Core'
 
   def creds(opts = {})
-    json_to_open_struct_object(self.get_data(CREDENTIAL_PATH, opts), [])
+    json_to_mdm_object(self.get_data(CREDENTIAL_API_PATH, opts), CREDENTIAL_MDM_CLASS, [])
   end
 
   def create_credential(opts)
-    self.post_data_async(CREDENTIAL_PATH, opts)
+    self.post_data_async(CREDENTIAL_API_PATH, opts)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_credential_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_credential_data_service.rb
@@ -8,7 +8,14 @@ module RemoteCredentialDataService
   CREDENTIAL_MDM_CLASS = 'Metasploit::Credential::Core'
 
   def creds(opts = {})
-    json_to_mdm_object(self.get_data(CREDENTIAL_API_PATH, opts), CREDENTIAL_MDM_CLASS, [])
+    data = self.get_data(CREDENTIAL_API_PATH, opts)
+    rv = json_to_mdm_object(data, CREDENTIAL_MDM_CLASS, [])
+    parsed_body = JSON.parse(data.response.body)
+    parsed_body.each do |cred|
+      private_object = to_ar(cred['private_class'].constantize, cred['private'])
+      rv[parsed_body.index(cred)].private = private_object
+    end
+    rv
   end
 
   def create_credential(opts)

--- a/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
@@ -3,27 +3,28 @@ require 'metasploit/framework/data_service/remote/http/response_data_helper'
 module RemoteHostDataService
   include ResponseDataHelper
 
-  HOST_PATH = '/api/1/msf/host'
-  HOST_SEARCH_PATH = HOST_PATH + "/search"
+  HOST_API_PATH = '/api/1/msf/host'
+  HOST_SEARCH_PATH = HOST_API_PATH + "/search"
+  HOST_MDM_CLASS = 'Mdm::Host'
 
   def hosts(opts)
-    json_to_open_struct_object(self.get_data(HOST_PATH, opts), [])
+    json_to_mdm_object(self.get_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
   end
 
   def report_host(opts)
-    json_to_open_struct_object(self.post_data(HOST_PATH, opts))
+    json_to_mdm_object(self.get_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
   end
 
   def find_or_create_host(opts)
-    json_to_open_struct_object(self.post_data(HOST_PATH, opts))
+    json_to_mdm_object(self.get_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
   end
 
   def report_hosts(hosts)
-    self.post_data(HOST_PATH, hosts)
+    self.post_data(HOST_API_PATH, hosts)
   end
 
   def delete_host(opts)
-    json_to_open_struct_object(self.delete_data(HOST_PATH, opts))
+    json_to_mdm_object(self.get_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
   end
 
   # TODO: Remove? What is the purpose of this method?

--- a/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
@@ -12,11 +12,11 @@ module RemoteHostDataService
   end
 
   def report_host(opts)
-    json_to_mdm_object(self.get_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
+    json_to_mdm_object(self.post_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
   end
 
   def find_or_create_host(opts)
-    json_to_mdm_object(self.get_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
+    json_to_mdm_object(self.post_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
   end
 
   def report_hosts(hosts)
@@ -24,7 +24,7 @@ module RemoteHostDataService
   end
 
   def delete_host(opts)
-    json_to_mdm_object(self.get_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
+    json_to_mdm_object(self.delete_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
   end
 
   # TODO: Remove? What is the purpose of this method?

--- a/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_host_data_service.rb
@@ -12,11 +12,11 @@ module RemoteHostDataService
   end
 
   def report_host(opts)
-    json_to_mdm_object(self.post_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
+    json_to_mdm_object(self.post_data(HOST_API_PATH, opts), HOST_MDM_CLASS, []).first
   end
 
   def find_or_create_host(opts)
-    json_to_mdm_object(self.post_data(HOST_API_PATH, opts), HOST_MDM_CLASS, [])
+    json_to_mdm_object(self.post_data(HOST_API_PATH, opts), HOST_MDM_CLASS, []).first
   end
 
   def report_hosts(hosts)

--- a/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
@@ -3,11 +3,12 @@ require 'metasploit/framework/data_service/remote/http/response_data_helper'
 module RemoteLootDataService
   include ResponseDataHelper
 
-  LOOT_PATH = '/api/1/msf/loot'
+  LOOT_API_PATH = '/api/1/msf/loot'
+  LOOT_MDM_CLASS = 'Mdm::Loot'
 
   def loot(opts = {})
     # TODO: Add an option to toggle whether the file data is returned or not
-    loots = json_to_open_struct_object(self.get_data(LOOT_PATH, opts), [])
+    loots = json_to_mdm_object(self.get_data(LOOT_API_PATH, opts), LOOT_MDM_CLASS, [])
     # Save a local copy of the file
     loots.each do |loot|
       if loot.data
@@ -19,14 +20,14 @@ module RemoteLootDataService
   end
 
   def report_loot(opts)
-    self.post_data_async(LOOT_PATH, opts)
+    self.post_data_async(LOOT_API_PATH, opts)
   end
 
   def find_or_create_loot(opts)
-    json_to_open_struct_object(self.post_data(LOOT_PATH, opts))
+    json_to_mdm_object(self.get_data(LOOT_API_PATH, opts), LOOT_MDM_CLASS, [])
   end
 
   def report_loots(loot)
-    self.post_data(LOOT_PATH, loot)
+    self.post_data(LOOT_API_PATH, loot)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb
@@ -24,7 +24,7 @@ module RemoteLootDataService
   end
 
   def find_or_create_loot(opts)
-    json_to_mdm_object(self.get_data(LOOT_API_PATH, opts), LOOT_MDM_CLASS, [])
+    json_to_mdm_object(self.post_data(LOOT_API_PATH, opts), LOOT_MDM_CLASS, [])
   end
 
   def report_loots(loot)

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
@@ -1,6 +1,7 @@
 module RemoteSessionDataService
 
   SESSION_API_PATH = '/api/1/msf/session'
+  SESSION_MDM_CLASS = 'Mdm::Session'
 
   def report_session(opts)
     session = opts[:session]
@@ -12,7 +13,7 @@ module RemoteSessionDataService
     end
 
     opts[:time_stamp] = Time.now.utc
-    sess_db = json_to_open_struct_object(self.post_data(SESSION_API_PATH, opts))
+    sess_db = json_to_mdm_object(self.get_data(SESSION_API_PATH, opts), SESSION_MDM_CLASS, [])
     session.db_record = sess_db
   end
 

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_data_service.rb
@@ -13,7 +13,7 @@ module RemoteSessionDataService
     end
 
     opts[:time_stamp] = Time.now.utc
-    sess_db = json_to_mdm_object(self.get_data(SESSION_API_PATH, opts), SESSION_MDM_CLASS, [])
+    sess_db = json_to_mdm_object(self.post_data(SESSION_API_PATH, opts), SESSION_MDM_CLASS, []).first
     session.db_record = sess_db
   end
 

--- a/lib/metasploit/framework/data_service/remote/http/remote_session_event_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_session_event_data_service.rb
@@ -3,14 +3,15 @@ require 'metasploit/framework/data_service/remote/http/response_data_helper'
 module RemoteSessionEventDataService
   include ResponseDataHelper
 
-  SESSION_EVENT_PATH = '/api/1/msf/session_event'
+  SESSION_EVENT_API_PATH = '/api/1/msf/session_event'
+  SESSION_EVENT_MDM_CLASS = 'Mdm::SessionEvent'
 
   def session_events(opts = {})
-    json_to_open_struct_object(self.get_data(SESSION_EVENT_PATH, opts), [])
+    json_to_mdm_object(self.get_data(SESSION_EVENT_API_PATH, opts), SESSION_EVENT_MDM_CLASS, [])
   end
 
   def report_session_event(opts)
     opts[:session] = opts[:session].db_record
-    self.post_data_async(SESSION_EVENT_PATH, opts)
+    self.post_data_async(SESSION_EVENT_API_PATH, opts)
   end
 end

--- a/lib/metasploit/framework/data_service/remote/http/remote_workspace_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/http/remote_workspace_data_service.rb
@@ -5,19 +5,20 @@ module RemoteWorkspaceDataService
 
   WORKSPACE_COUNTS_API_PATH = '/api/1/msf/workspace/counts'
   WORKSPACE_API_PATH = '/api/1/msf/workspace'
+  WORKSPACE_MDM_CLASS = 'Mdm::Workspace'
   DEFAULT_WORKSPACE_NAME = 'default'
 
   def find_workspace(workspace_name)
     workspace = workspace_cache[workspace_name]
     return workspace unless (workspace.nil?)
 
-    workspace = json_to_open_struct_object(self.get_data(WORKSPACE_API_PATH, {:workspace_name => workspace_name}))
+    workspace = json_to_mdm_object(self.get_data(WORKSPACE_API_PATH, {:workspace_name => workspace_name}), WORKSPACE_MDM_CLASS).first
     workspace_cache[workspace_name] = workspace
   end
 
   def add_workspace(workspace_name)
     response = self.post_data(WORKSPACE_API_PATH, {:workspace_name => workspace_name})
-    json_to_open_struct_object(response, nil)
+    json_to_mdm_object(response, WORKSPACE_MDM_CLASS, nil)
   end
 
   def default_workspace
@@ -33,11 +34,11 @@ module RemoteWorkspaceDataService
   end
 
   def workspaces
-    json_to_open_struct_object(self.get_data(WORKSPACE_API_PATH, {:all => true}), [])
+    json_to_mdm_object(self.get_data(WORKSPACE_API_PATH, {:all => true}), WORKSPACE_MDM_CLASS, [])
   end
 
   def workspace_associations_counts()
-    json_to_open_struct_object(self.get_data(WORKSPACE_COUNTS_API_PATH), [])
+    json_to_mdm_object(self.get_data(WORKSPACE_API_PATH, []), WORKSPACE_MDM_CLASS, [])
   end
 
   #########

--- a/lib/msf/core/db_manager/host.rb
+++ b/lib/msf/core/db_manager/host.rb
@@ -31,16 +31,14 @@ module Msf::DBManager::Host
       deleted = []
       hosts.each do |host|
         begin
-          host.destroy
-          deleted << host.address.to_s
+          deleted << host.destroy
         rescue # refs suck
           elog("Forcibly deleting #{host.address}")
-          host.delete
-          deleted << host.address.to_s
+          deleted << host.delete
         end
       end
 
-      return { deleted: deleted }
+      return deleted
     }
   end
 

--- a/lib/msf/core/db_manager/http/servlet/credential_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/credential_servlet.rb
@@ -23,7 +23,7 @@ module CredentialServlet
         # This is normally pulled from a class method from the MetasploitCredential class
         response = []
         data.each do |cred|
-          json = cred.as_json(include: includes).merge('human' => cred.private.class.model_name.human)
+          json = cred.as_json(include: includes).merge('private_class' => cred.private.class.to_s)
           response << json
         end
         set_json_response(response)

--- a/lib/msf/core/db_manager/http/servlet/credential_servlet.rb
+++ b/lib/msf/core/db_manager/http/servlet/credential_servlet.rb
@@ -18,7 +18,7 @@ module CredentialServlet
       begin
         opts = parse_json_request(request, false)
         data = get_db().creds(opts)
-        includes = [:logins, :public, :private, :origin, :realm]
+        includes = [:logins, :public, :private, :realm]
         # Need to append the human attribute into the private sub-object before converting to json
         # This is normally pulled from a class method from the MetasploitCredential class
         response = []

--- a/lib/msf/ui/console/command_dispatcher/creds.rb
+++ b/lib/msf/ui/console/command_dispatcher/creds.rb
@@ -424,16 +424,7 @@ class Creds
         public_val = core.public ? core.public.username : ""
         private_val = core.private ? core.private.data : ""
         realm_val = core.realm ? core.realm.value : ""
-        human_val = ""
-        # TODO: We shouldn't have separate code paths depending on the model we're working with
-        # This should always expect an OpenStruct.
-        if core.private
-          if core.private.is_a?(OpenStruct)
-            human_val = core.human
-          else
-            human_val = core.private.class.model_name.human
-          end
-        end
+        human_val = core.private ? core.private.class.model_name.human : ""
 
         tbl << [
           "", # host
@@ -442,7 +433,7 @@ class Creds
           public_val,
           private_val,
           realm_val,
-          human_val,
+          human_val
         ]
       else
         core.logins.each do |login|
@@ -466,22 +457,13 @@ class Creds
           public_val = core.public ? core.public.username : ""
           private_val = core.private ? core.private.data : ""
           realm_val = core.realm ? core.realm.value : ""
-          human_val = ""
-          # TODO: We shouldn't have separate code paths depending on the model we're working with
-          # This should always expect an OpenStruct.
-          if core.private
-            if core.private.is_a?(OpenStruct)
-              human_val = core.human
-            else
-              human_val = core.private.class.model_name.human
-            end
-          end
+          human_val = core.private ? core.private.class.model_name.human : ""
 
           row += [
             public_val,
             private_val,
             realm_val,
-            human_val,
+            human_val
           ]
           tbl << row
         end

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -659,7 +659,7 @@ module Msf
 
               if mode == [:delete]
                 result = framework.db.delete_host(workspace: framework.db.workspace, addresses: host_search)
-                delete_count += result[:deleted].size
+                delete_count += result.size
               end
             end
 


### PR DESCRIPTION
This PR adds a couple of new methods to enable us to deserialize JSON returned from a remote data service to an in-memory MDM object. This will allow easier compatibility with existing code on the framework side while working through conversions to use the remote data service.

Longer term we will use the Mdm object as the abstraction layer and change the backend, but keep the overall object method calls the same with the same functionality, reducing code movement on the framework side.

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole` and `msfdb`
- [x] Connect `msfconsole` to the remote data service
- [x] Perform regression testing. Add some data, delete some data, pop shells, gather loot. Verify `hosts`, `loot`, etc commands still work.
