### PR TITLE
Standardize Data Proxy Error Handling

### DIFF
--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -118,7 +118,7 @@ class DataProxy
   def log_error(exception, ui_message)
     elog "#{ui_message}: #{exception.message}"
     exception.backtrace.each { |line| elog "#{line}" }
-    raise Exception, "#{ui_message}. See log for more details."
+    raise Exception, "#{ui_message}: #{exception.message}. See log for more details."
   end
 
   #######

--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -118,6 +118,8 @@ class DataProxy
   def log_error(exception, ui_message)
     elog "#{ui_message}: #{exception.message}"
     exception.backtrace.each { |line| elog "#{line}" }
+    # TODO: We should try to surface the original exception, instead of just a generic one.
+    # This should not display the full backtrace, only the message.
     raise Exception, "#{ui_message}: #{exception.message}. See log for more details."
   end
 

--- a/lib/metasploit/framework/data_service/proxy/core.rb
+++ b/lib/metasploit/framework/data_service/proxy/core.rb
@@ -115,6 +115,12 @@ class DataProxy
     return @current_data_service
   end
 
+  def log_error(exception, ui_message)
+    elog "#{ui_message}: #{exception.message}"
+    exception.backtrace.each { |line| elog "#{line}" }
+    raise Exception, "#{ui_message}. See log for more details."
+  end
+
   #######
   private
   #######

--- a/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/credential_data_proxy.rb
@@ -5,7 +5,7 @@ module CredentialDataProxy
       data_service = self.get_data_service()
       data_service.create_credential(opts)
     rescue Exception => e
-      elog "Problem creating credential: #{e.message}"
+      self.log_error(e, "Problem creating credential")
     end
   end
 
@@ -14,7 +14,7 @@ module CredentialDataProxy
       data_service = self.get_data_service
       data_service.creds(opts)
     rescue Exception => e
-      elog "Problem retrieving credentials: #{e.message}"
+      self.log_error(e, "Problem retrieving credentials")
     end
   end
 end

--- a/lib/metasploit/framework/data_service/proxy/event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/event_data_proxy.rb
@@ -5,7 +5,7 @@ module EventDataProxy
       data_service = self.get_data_service()
       data_service.report_event(opts)
     rescue  Exception => e
-      elog "Problem reporting event: #{e.message}"
+      self.log_error(e, "Problem reporting event")
     end
   end
 

--- a/lib/metasploit/framework/data_service/proxy/exploit_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/exploit_data_proxy.rb
@@ -5,7 +5,7 @@ module ExploitDataProxy
       data_service = self.get_data_service()
       data_service.report_exploit_attempt(host, opts)
     rescue  Exception => e
-      elog "Problem reporting exploit attempt: #{e.message}"
+      self.log_error(e, "Problem reporting exploit attempt")
     end
   end
 
@@ -14,7 +14,7 @@ module ExploitDataProxy
       data_service = self.get_data_service()
       data_service.report_exploit_failure(opts)
     rescue  Exception => e
-      elog "Problem reporting exploit failure: #{e.message}"
+      self.log_error(e, "Problem reporting exploit failure")
     end
   end
 
@@ -23,7 +23,7 @@ module ExploitDataProxy
       data_service = self.get_data_service()
       data_service.report_exploit_success(opts)
     rescue  Exception => e
-      elog "Problem reporting exploit success: #{e.message}"
+      self.log_error(e, "Problem reporting exploit success")
     end
   end
 end

--- a/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/host_data_proxy.rb
@@ -10,7 +10,7 @@ module HostDataProxy
       opts[:search_term] = search_term
       data_service.hosts(opts)
     rescue Exception => e
-      elog "Problem retrieving hosts: #{e.message}"
+      self.log_error(e, "Problem retrieving hosts")
     end
   end
 
@@ -27,7 +27,7 @@ module HostDataProxy
       data_service = self.get_data_service()
       data_service.report_host(opts)
     rescue Exception => e
-      elog "Problem reporting host: #{e.message}"
+      self.log_error(e, "Problem reporting host")
     end
   end
 
@@ -36,7 +36,7 @@ module HostDataProxy
       data_service = self.get_data_service()
       data_service.report_hosts(hosts)
     rescue Exception => e
-      elog "Problem reporting hosts: #{e.message}"
+      self.log_error(e, "Problem reporting hosts")
     end
   end
 
@@ -45,7 +45,7 @@ module HostDataProxy
       data_service = self.get_data_service()
       data_service.update_host(opts)
     rescue Exception => e
-      elog "Problem updating host: #{e.message}"
+      self.log_error(e, "Problem updating host")
     end
   end
 
@@ -54,7 +54,7 @@ module HostDataProxy
       data_service = self.get_data_service()
       data_service.delete_host(opts)
     rescue Exception => e
-      elog "Problem removing host: #{e.message}"
+      self.log_error(e, "Problem deleting host")
     end
   end
 

--- a/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb
@@ -8,7 +8,7 @@ module LootDataProxy
       end
       data_service.report_loot(opts)
     rescue Exception => e
-      elog "Problem reporting loot: #{e.message}"
+      self.log_error(e, "Problem reporting loot")
     end
   end
 
@@ -24,8 +24,7 @@ module LootDataProxy
       opts[:wspace] = wspace
       data_service.loot(opts)
     rescue Exception => e
-      elog "Problem retrieving loot: #{e.message}"
-      e.backtrace.each { |line| elog "#{line}\n" }
+      self.log_error(e, "Problem retrieving loot")
     end
   end
 
@@ -36,8 +35,7 @@ module LootDataProxy
       data_service = self.get_data_service
       data_service.update_loot(opts)
     rescue Exception => e
-      elog "Problem updating loot: #{e.message}"
-      e.backtrace.each { |line| elog "#{line}\n" }
+      self.log_error(e, "Problem updating loot")
     end
   end
 end

--- a/lib/metasploit/framework/data_service/proxy/nmap_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/nmap_data_proxy.rb
@@ -5,7 +5,7 @@ module NmapDataProxy
       data_service = self.get_data_service()
       data_service.import_nmap_xml_file(args)
     rescue Exception => e
-      elog "Problem importing NMAP XML: #{e.message}"
+      self.log_error(e, "Problem importing nmap XML file")
     end
   end
 end

--- a/lib/metasploit/framework/data_service/proxy/nmap_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/nmap_data_proxy.rb
@@ -5,7 +5,7 @@ module NmapDataProxy
       data_service = self.get_data_service()
       data_service.import_nmap_xml_file(args)
     rescue Exception => e
-      self.log_error(e, "Problem importing nmap XML file")
+      self.log_error(e, "Problem importing Nmap XML file")
     end
   end
 end

--- a/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/note_data_proxy.rb
@@ -4,7 +4,7 @@ module NoteDataProxy
       data_service = self.get_data_service()
       data_service.report_note(opts)
     rescue  Exception => e
-      elog "Problem reporting note: #{e.message}"
+      self.log_error(e, "Problem reporting note")
     end
   end
 end

--- a/lib/metasploit/framework/data_service/proxy/service_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/service_data_proxy.rb
@@ -5,7 +5,7 @@ module ServiceDataProxy
       data_service = self.get_data_service()
       data_service.report_service(opts)
     rescue  Exception => e
-      elog "Problem reporting service: #{e.message}"
+      self.log_error(e, "Problem reporting service")
     end
   end
 

--- a/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_data_proxy.rb
@@ -4,7 +4,7 @@ module SessionDataProxy
       data_service = self.get_data_service()
       data_service.report_session(opts)
     rescue  Exception => e
-      elog "Problem reporting session: #{e.message}"
+      self.log_error(e, "Problem reporting session")
     end
   end
 end

--- a/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/session_event_data_proxy.rb
@@ -5,7 +5,7 @@ module SessionEventDataProxy
       data_service = self.get_data_service()
       data_service.report_session_event(opts)
     rescue Exception => e
-      elog "Problem reporting session event: #{e.message}"
+      self.log_error(e, "Problem reporting session event")
     end
   end
 end

--- a/lib/metasploit/framework/data_service/proxy/vuln_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/vuln_data_proxy.rb
@@ -5,7 +5,7 @@ module VulnDataProxy
       data_service = self.get_data_service()
       data_service.report_vuln(opts)
     rescue  Exception => e
-      self.log_error(e, "Problem ")
+      self.log_error(e, "Problem reporting vuln")
     end
   end
 

--- a/lib/metasploit/framework/data_service/proxy/vuln_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/vuln_data_proxy.rb
@@ -5,7 +5,7 @@ module VulnDataProxy
       data_service = self.get_data_service()
       data_service.report_vuln(opts)
     rescue  Exception => e
-      elog "Problem reporting vulnerability: #{e.message}"
+      self.log_error(e, "Problem ")
     end
   end
 

--- a/lib/metasploit/framework/data_service/proxy/web_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/web_data_proxy.rb
@@ -4,7 +4,7 @@ module WebDataProxy
       data_service = self.get_data_service()
       data_service.report_web_site(opts)
     rescue  Exception => e
-      elog "Problem reporting web site: #{e.message}"
+      self.log_error(e, "Problem reporting website")
     end
   end
 end

--- a/lib/metasploit/framework/data_service/proxy/workspace_data_proxy.rb
+++ b/lib/metasploit/framework/data_service/proxy/workspace_data_proxy.rb
@@ -5,7 +5,7 @@ module WorkspaceDataProxy
       data_service = self.get_data_service()
       data_service.find_workspace(workspace_name)
     rescue  Exception => e
-      elog "Problem finding workspace: #{e.message}"
+      self.log_error(e, "Problem finding workspace")
     end
   end
 
@@ -14,7 +14,7 @@ module WorkspaceDataProxy
       data_service = self.get_data_service()
       data_service.add_workspace(workspace_name)
     rescue  Exception => e
-      elog "Problem adding workspace: #{e.message}"
+      self.log_error(e, "Problem adding workspace")
     end
   end
 
@@ -23,7 +23,7 @@ module WorkspaceDataProxy
       data_service = self.get_data_service()
       data_service.default_workspace
     rescue  Exception => e
-      elog "Problem getting the default workspace: #{e.message}"
+      self.log_error(e, "Problem finding default workspace")
     end
   end
 
@@ -32,7 +32,7 @@ module WorkspaceDataProxy
       data_service = self.get_data_service()
       data_service.workspace
     rescue  Exception => e
-      elog "Problem retrieving workspace: #{e.message}"
+      self.log_error(e, "Problem retrieving workspace")
     end
   end
 
@@ -41,7 +41,7 @@ module WorkspaceDataProxy
       data_service = self.get_data_service()
       data_service.workspace = workspace
     rescue  Exception => e
-      elog "Problem setting workspace: #{e.message}"
+      self.log_error(e, "Problem setting workspace")
     end
   end
 
@@ -50,7 +50,7 @@ module WorkspaceDataProxy
       data_service = self.get_data_service()
       data_service.workspaces
     rescue  Exception => e
-      elog "Problem retrieving workspaces: #{e.message}"
+      self.log_error(e, "Problem retrieving workspaces")
     end
   end
 
@@ -59,7 +59,7 @@ module WorkspaceDataProxy
       data_service = self.get_data_service()
       data_service.workspace_associations_counts()
     rescue  Exception => e
-      elog "Problem retrieving workspaces counts: #{e.message}"
+      self.log_error(e, "Problem retrieving workspace counts")
     end
   end
 


### PR DESCRIPTION
This PR sets a standard method to use for all error handling within the data proxies. The output when an error occurs will now look like this:

```
msf5 > loot
[-] Error while running command loot: There was a problem retrieving loot. See log for more details.
```

The `~/.msf4/logs/framework.log` file will contain the following:

```
[02/09/2018 16:09:03] [e(0)] core: Problem retrieving loot: invalid base64
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/.rvm/rubies/ruby-2.4.2/lib/ruby/2.4.0/base64.rb:74:in `unpack'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/.rvm/rubies/ruby-2.4.2/lib/ruby/2.4.0/base64.rb:74:in `strict_decode64'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/.rvm/rubies/ruby-2.4.2/lib/ruby/2.4.0/base64.rb:105:in `urlsafe_decode64'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/metasploit/framework/data_service/remote/http/response_data_helper.rb:62:in `process_file'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb:16:in `block in loot'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb:13:in `each'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/metasploit/framework/data_service/remote/http/remote_loot_data_service.rb:13:in `loot'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/metasploit/framework/data_service/proxy/loot_data_proxy.rb:27:in `loots'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/msf/ui/console/command_dispatcher/db.rb:1211:in `cmd_loot'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/rex/ui/text/dispatcher_shell.rb:548:in `run_command'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/rex/ui/text/dispatcher_shell.rb:510:in `block in run_single'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/rex/ui/text/dispatcher_shell.rb:504:in `each'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/rex/ui/text/dispatcher_shell.rb:504:in `run_single'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/rex/ui/text/shell.rb:206:in `run'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/metasploit/framework/command/console.rb:48:in `start'
[02/09/2018 16:09:03] [e(0)] core: /Users/jbarnett/rapid7/goliath/lib/metasploit/framework/command/base.rb:88:in `start'
[02/09/2018 16:09:03] [e(0)] core: ./msfconsole:48:in `<main>'

```

## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] Create a loot entry `loot -a 172.1.1.1 -i infotest -t typetest -f <path/to/file>`
- [x] Add a remote data service `data_services -a 127.0.0.1 -p 8080`
- [ ] Call the `loot` command. It should generate an error.
- [ ] Verify the log has the correct entry `~/.msf4/logs/framework.log`
- [ ] Generate other error messages in other proxies to ensure that they behave the same way
